### PR TITLE
Provide more docker tags

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -29,6 +29,15 @@
   registry: https://index.docker.io/v1/
   encrypted_dockercfg_path: dockercfg.encrypted
 
+- name: push_latest_tag
+  service: portal
+  type: push
+  image_name: silintl/developer-portal
+  image_tag: "latest"
+  tag: master
+  registry: https://index.docker.io/v1/
+  encrypted_dockercfg_path: dockercfg.encrypted
+
 - name: deploy_staging
   service: ecsdeploy
   tag: develop

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -11,6 +11,15 @@
   registry: https://index.docker.io/v1/
   encrypted_dockercfg_path: dockercfg.encrypted
 
+- name: push_branch_tag
+  service: portal
+  type: push
+  image_name: silintl/developer-portal
+  image_tag: "{{.Branch}}"
+  exclude: master
+  registry: https://index.docker.io/v1/
+  encrypted_dockercfg_path: dockercfg.encrypted
+
 - name: push_production
   service: portal
   type: push


### PR DESCRIPTION
This is in preparation for using this repo's docker image as a base for a skinny repo used to control a separate instance of this developer portal website.