### PR TITLE
Just use 'Login' where there is only one login option

### DIFF
--- a/application/protected/components/AuthManager.php
+++ b/application/protected/components/AuthManager.php
@@ -72,6 +72,20 @@ class AuthManager
     }
     
     /**
+     * Get the URL for the default login option (if there is one).
+     * 
+     * @return string|null The URL, or null if there is no default.
+     */
+    public function getDefaultLoginOptionUrl()
+    {
+        $loginOptions = $this->getLoginOptions();
+        if (count($loginOptions) === 1) {
+            return $loginOptions[0]->getUrl();
+        }
+        return null;
+    }
+    
+    /**
      * If there is a default provider for the given auth. type, return (the
      * slugified version of) it, regardless of whether that auth. type is
      * currently enabled.

--- a/application/protected/components/LoginOption.php
+++ b/application/protected/components/LoginOption.php
@@ -76,6 +76,24 @@ class LoginOption
     }
     
     /**
+     * Get the full link HTML (with logo, if available) to use when there is
+     * only a single login option.
+     * 
+     * @param string $extraCssClassString (Optional:) Any additional CSS class
+     *     string content that you want.
+     * @return string
+     */
+    public function getSingleOptionLinkHtml($extraCssClassString = '')
+    {
+        return sprintf(
+            '<a href="%s" class="btn btn-success login-logo-button %s">%s</a>',
+            \CHtml::encode($this->getUrl()),
+            \CHtml::encode($extraCssClassString),
+            'Login'
+        );
+    }
+    
+    /**
      * Get the (relative) URL for logging in with this login option.
      * 
      * @return string

--- a/application/protected/views/layouts/main.php
+++ b/application/protected/views/layouts/main.php
@@ -21,6 +21,8 @@ use Sil\DevPortal\components\AuthManager;
 <body id="body">
 <?php 
 
+$authManager = new AuthManager();
+
 // Set up the menu.
 $this->widget('bootstrap.widgets.TbNavbar', array(
     'type' => 'inverse',
@@ -107,8 +109,13 @@ $this->widget('bootstrap.widgets.TbNavbar', array(
             'items' => array(
                 array(
                     'label' => 'Login',
-                    'visible' => Yii::app()->user->isGuest,
+                    'visible' => Yii::app()->user->isGuest && $authManager->canUseMultipleAuthTypes(),
                     'items' => AuthManager::getLoginMenuItems(),
+                ),
+                array(
+                    'label' => 'Login',
+                    'visible' => Yii::app()->user->isGuest && !$authManager->canUseMultipleAuthTypes(),
+                    'url' => $authManager->getDefaultLoginOptionUrl(),
                 ),
                 array(
                     'label' => Yii::app()->user->name,

--- a/application/protected/views/site/index.php
+++ b/application/protected/views/site/index.php
@@ -23,9 +23,13 @@ $this->pageTitle = 'Welcome';
                 <div id="get-started">
                     <h2>Get Started</h2>
                     <div style="display: inline-block;">
-                        <?php foreach ($loginOptions as $loginOption): ?>
-                            <div style="margin: 4px;"><?= $loginOption->getLinkHtml(); ?></div>
-                        <?php endforeach; ?>
+                        <?php if (count($loginOptions) === 1): ?>
+                            <div style="margin: 4px;"><?= $loginOptions[0]->getSingleOptionLinkHtml(); ?></div>
+                        <?php else: ?>
+                            <?php foreach ($loginOptions as $loginOption): ?>
+                                <div style="margin: 4px;"><?= $loginOption->getLinkHtml(); ?></div>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Rather than saying "Login with _(something)_" (as we do when there are multiple login options), this simplifies it to simply say "Login" when there is only one login option.

It also changes the Login drop-down menu in the navbar to simply be a Login button (when there is only one login option).