### PR TITLE
Update SimpleSAMLphp

### DIFF
--- a/application/composer.json
+++ b/application/composer.json
@@ -10,7 +10,7 @@
         "hybridauth/hybridauth": "^2.8.2",
         "silinternational/php-env": "0.*",
         "silinternational/apiaxle-sdk-php": "^1.0",
-        "simplesamlphp/simplesamlphp": "~1.15.4",
+        "simplesamlphp/simplesamlphp": "~1.16.3",
         "guzzlehttp/guzzle-services": "^0.6",
         "roave/security-advisories": "dev-master"
     },

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3a4fbe8d65b86eb177574dcdddaffd4",
+    "content-hash": "433ae75e06f6872bbb2cbc4734c6525c",
     "packages": [
         {
             "name": "danielstjules/stringy",
@@ -1153,16 +1153,16 @@
         },
         {
             "name": "simplesamlphp/saml2",
-            "version": "v3.1.6",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "d809ffbe2aa7260a0b3e72bf5be8cd6de0325d7c"
+                "reference": "a56e46ef8e0c5245a4ca7facc3d308b493215751"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/d809ffbe2aa7260a0b3e72bf5be8cd6de0325d7c",
-                "reference": "d809ffbe2aa7260a0b3e72bf5be8cd6de0325d7c",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/a56e46ef8e0c5245a4ca7facc3d308b493215751",
+                "reference": "a56e46ef8e0c5245a4ca7facc3d308b493215751",
                 "shasum": ""
             },
             "require": {
@@ -1206,20 +1206,20 @@
                 }
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
-            "time": "2018-05-04T12:03:18+00:00"
+            "time": "2018-11-20T11:11:28+00:00"
         },
         {
             "name": "simplesamlphp/simplesamlphp",
-            "version": "v1.15.4",
+            "version": "1.16.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/simplesamlphp.git",
-                "reference": "c770d0cd392ba8d8b12ac6214dcabd818d7cca32"
+                "reference": "abc208dbc9c94eb8bab8266825ca035cc96072ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/simplesamlphp/zipball/c770d0cd392ba8d8b12ac6214dcabd818d7cca32",
-                "reference": "c770d0cd392ba8d8b12ac6214dcabd818d7cca32",
+                "url": "https://api.github.com/repos/simplesamlphp/simplesamlphp/zipball/abc208dbc9c94eb8bab8266825ca035cc96072ba",
+                "reference": "abc208dbc9c94eb8bab8266825ca035cc96072ba",
                 "shasum": ""
             },
             "require": {
@@ -1235,15 +1235,15 @@
                 "gettext/gettext": "^3.5",
                 "jaimeperez/twig-configurable-i18n": "^1.2",
                 "php": ">=5.4",
-                "robrichards/xmlseclibs": "~3.0",
-                "simplesamlphp/saml2": "~3.1.4",
+                "robrichards/xmlseclibs": "^3.0",
+                "simplesamlphp/saml2": "~3.2.2",
                 "twig/twig": "~1.0",
                 "whitehat101/apr1-md5": "~1.0"
             },
             "require-dev": {
-                "ext-pdo_sqlite": "*",
+                "friendsofphp/php-cs-fixer": "^2.2",
                 "mikey179/vfsstream": "~1.6",
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "~4.8.35"
             },
             "type": "project",
             "autoload": {
@@ -1282,7 +1282,7 @@
                 "sp",
                 "ws-federation"
             ],
-            "time": "2018-03-02T15:02:24+00:00"
+            "time": "2018-12-20T16:49:03+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/application/public/index.php
+++ b/application/public/index.php
@@ -24,5 +24,7 @@ if (APPLICATION_ENV === 'development') {
     defined('YII_TRACE_LEVEL') or define('YII_TRACE_LEVEL', 3);
 }
 
+Yii::$enableIncludePath = false; // disable PHP include path usage
+
 // Run the application with the resulting config settings.
 Yii::createWebApplication($config)->run();


### PR DESCRIPTION
**Security:**
- Update SimpleSAMLphp to non-vulnerable version (1.16.3)

---

Setting `Yii::$enableIncludePath` to `false` prevent's Yii from looking
in the PATH as a "last resort" and throwing an exception if it can't find
the class. That lets the next autoloader (composer's) try, which finds
it, resolving a "Class not found" error that we started seeing after
updating SSP.