### PR TITLE
Improve handling of dependencies and SSP override files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN ["apache2ctl", "configtest"]
 # Copy the SimpleSAMLphp configuration files to a temporary location
 COPY build/ssp-overrides /tmp/ssp-overrides
 
+# Put in place the script to be used by child Docker images to install Composer
+# dependencies and move the SSP overrides into place.
+COPY build/install-deps-and-ssp-overrides.sh /tmp
+
 # Copy in any additional PHP ini files
 COPY build/php/*.ini "$PHP_INI_DIR/conf.d/"
 

--- a/README.md
+++ b/README.md
@@ -8,33 +8,38 @@ This website is available as a Docker image here:
 We recommend using that as the `FROM` in your own Dockerfile in your own
 private repo, where you would `COPY` into your own Docker image the files needed
 by SimpleSAMLphp (if using SAML logins), your own
-`/data/public/img/logos/site-logo.png`, etc. Your Dockerfile should put the
-SAML files into `/tmp/ssp-overrides`, since the `run.sh` script will copy from
-there into the SimpleSAMLphp folders within the `vendor` folder after installing
-composer dependencies.
+`/data/public/img/logos/site-logo.png`, etc.
+
+Your Dockerfile should (in this order)...
+
+1. Put any custom SAML files into `/tmp/ssp-overrides`.
+2. Run the `/tmp/install-deps-and-ssp-overrides.sh`, since it will move the SAML
+   files into the SimpleSAMLphp folders within the `vendor` folder after
+   installing composer dependencies.
 
 ### Example Dockerfile using this as the FROM ###
 
-    FROM silintl/developer-portal:1.3.4 
-
-    # Make sure /data is available
-    RUN mkdir -p /data
-
-    # Copy in a custom vhost configuration (if necessary)
-    COPY build/vhost.conf /etc/apache2/sites-enabled/
-
-    # Copy the SimpleSAMLphp configuration files to a temporary location
+    FROM silintl/developer-portal:4.0.0
+    
+    ENV REFRESHED_AT 2021-04-08
+    
+    # Put in place any additional custom SAML files:
     COPY build/ssp-overrides /tmp/ssp-overrides
-
+    
+    # Put dependencies and SSP overrides in their final location
+    RUN /tmp/install-deps-and-ssp-overrides.sh
+    
+    # Copy in any custom files needed, which are stored in this repo.
+    COPY build/favicons /data/public
     COPY build/logos /data/public/img/logos
-
+    
     WORKDIR /data
-
+    
     EXPOSE 80
-
+    
     # Record now as the build date/time (in a friendly format).
     RUN date -u +"%B %-d, %Y, %-I:%M%P (%Z)" > /data/protected/data/version.txt
-
+    
     CMD ["/data/run.sh"]
 
 

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -4,7 +4,8 @@ echo "Running run-tests.sh, started at: $CI_TIMESTAMP"
 
 # Install composer dependencies
 cd /data
-runny composer install --no-scripts --optimize-autoloader --no-interaction
+echo "Installing dev dependencies..."
+runny composer install --no-scripts --no-interaction
 
 mkdir -p -v /data/vendor/simplesamlphp/simplesamlphp/cert
 cp /tmp/ssp-overrides/cert/* /data/vendor/simplesamlphp/simplesamlphp/cert
@@ -29,9 +30,6 @@ echo -e "Linking key to api...\n\n"
 curl -X PUT 'http://api/v1/api/apiaxle/linkkey/developer-portal-dev-key'
 
 # Run phpunit tests
-cd /data
-echo "Installing dev dependencies..."
-composer install --prefer-dist --no-interaction
 cd /data/protected/tests
 echo -e "Running tests\n\n"
 /data/vendor/bin/phpunit unit/

--- a/application/run.sh
+++ b/application/run.sh
@@ -10,9 +10,6 @@ if [[ "x" != "x$THEME_COLOR" ]]; then
     sed -i /data/public/css/styles.css -e "s/0068a6/${THEME_COLOR}/"
 fi
 
-# Install composer dependencies
-runny composer install --no-dev --no-scripts --optimize-autoloader --no-interaction
-
 mkdir -p -v /data/vendor/simplesamlphp/simplesamlphp/cert
 cp /tmp/ssp-overrides/cert/* /data/vendor/simplesamlphp/simplesamlphp/cert
 cp /tmp/ssp-overrides/config/* /data/vendor/simplesamlphp/simplesamlphp/config

--- a/application/run.sh
+++ b/application/run.sh
@@ -10,11 +10,6 @@ if [[ "x" != "x$THEME_COLOR" ]]; then
     sed -i /data/public/css/styles.css -e "s/0068a6/${THEME_COLOR}/"
 fi
 
-mkdir -p -v /data/vendor/simplesamlphp/simplesamlphp/cert
-cp /tmp/ssp-overrides/cert/* /data/vendor/simplesamlphp/simplesamlphp/cert
-cp /tmp/ssp-overrides/config/* /data/vendor/simplesamlphp/simplesamlphp/config
-cp /tmp/ssp-overrides/metadata/* /data/vendor/simplesamlphp/simplesamlphp/metadata
-
 # Run database migrations (exiting with an error if they fail)
 runny /data/protected/yiic migrate --interactive=0
 

--- a/build/install-deps-and-ssp-overrides.sh
+++ b/build/install-deps-and-ssp-overrides.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install composer dependencies
+cd /data
+composer install --no-dev --no-scripts --optimize-autoloader --no-interaction

--- a/build/install-deps-and-ssp-overrides.sh
+++ b/build/install-deps-and-ssp-overrides.sh
@@ -11,3 +11,4 @@ mkdir -p -v /data/vendor/simplesamlphp/simplesamlphp/cert
 cp /tmp/ssp-overrides/cert/* /data/vendor/simplesamlphp/simplesamlphp/cert
 cp /tmp/ssp-overrides/config/* /data/vendor/simplesamlphp/simplesamlphp/config
 cp /tmp/ssp-overrides/metadata/* /data/vendor/simplesamlphp/simplesamlphp/metadata
+rm -rf /tmp/ssp-overrides

--- a/build/install-deps-and-ssp-overrides.sh
+++ b/build/install-deps-and-ssp-overrides.sh
@@ -5,3 +5,9 @@ set -e
 # Install composer dependencies
 cd /data
 composer install --no-dev --no-scripts --optimize-autoloader --no-interaction
+
+# Copy the SSP override files into place
+mkdir -p -v /data/vendor/simplesamlphp/simplesamlphp/cert
+cp /tmp/ssp-overrides/cert/* /data/vendor/simplesamlphp/simplesamlphp/cert
+cp /tmp/ssp-overrides/config/* /data/vendor/simplesamlphp/simplesamlphp/config
+cp /tmp/ssp-overrides/metadata/* /data/vendor/simplesamlphp/simplesamlphp/metadata


### PR DESCRIPTION
### Changed
- Stop installing dependencies on startup. (Child Docker images must now do so.)
- Stop copying SSP override files into place on startup. (Child Docker images must now do so.)

### Added
- Add helper script to install deps and copy SSP overrides into place, for use in child Dockerfile.

### Fixed
- Stop double-installing (dev) dependencies in run-tests.sh script.
- Update documentation of steps child Docker images must do.