### PR TITLE
Fix script for installing dependencies and SSP overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY build/ssp-overrides /tmp/ssp-overrides
 # Put in place the script to be used by child Docker images to install Composer
 # dependencies and move the SSP overrides into place.
 COPY build/install-deps-and-ssp-overrides.sh /tmp
+RUN chmod +x /tmp/install-deps-and-ssp-overrides.sh
 
 # Copy in any additional PHP ini files
 COPY build/php/*.ini "$PHP_INI_DIR/conf.d/"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Your Dockerfile should (in this order)...
 
 ### Example Dockerfile using this as the FROM ###
 
-    FROM silintl/developer-portal:4.0.0
+    FROM silintl/developer-portal:4.0.1
     
     ENV REFRESHED_AT 2021-04-08
     

--- a/build/install-deps-and-ssp-overrides.sh
+++ b/build/install-deps-and-ssp-overrides.sh
@@ -8,7 +8,7 @@ composer install --no-dev --no-scripts --optimize-autoloader --no-interaction
 
 # Copy the SSP override files into place
 mkdir -p -v /data/vendor/simplesamlphp/simplesamlphp/cert
-cp /tmp/ssp-overrides/cert/* /data/vendor/simplesamlphp/simplesamlphp/cert
+find /tmp/ssp-overrides/ -path '/tmp/ssp-overrides/cert/*' -exec cp {} /data/vendor/simplesamlphp/simplesamlphp/cert \;
 cp /tmp/ssp-overrides/config/* /data/vendor/simplesamlphp/simplesamlphp/config
 cp /tmp/ssp-overrides/metadata/* /data/vendor/simplesamlphp/simplesamlphp/metadata
 rm -rf /tmp/ssp-overrides

--- a/build/install-deps-and-ssp-overrides.sh
+++ b/build/install-deps-and-ssp-overrides.sh
@@ -4,7 +4,7 @@ set -e
 
 # Install composer dependencies
 cd /data
-composer install --no-dev --no-scripts --optimize-autoloader --no-interaction
+composer install --no-dev --no-progress --no-scripts --optimize-autoloader --no-interaction
 
 # Copy the SSP override files into place
 mkdir -p -v /data/vendor/simplesamlphp/simplesamlphp/cert


### PR DESCRIPTION
### Fixed
- Make the script for installing dependencies, etc. executable
- Let script continue even if `/tmp/ssp-overrides/cert/` is absent or empty
- Have composer hide progress indicators when installing dependencies