### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM silintl/php7-apache:7.4.16
+FROM silintl/php7-apache:7.4.19
 LABEL maintainer="matt_henderson@sil.org"
 
 RUN apt-get update -y && \


### PR DESCRIPTION
`silintl/php7-apache` changed recently. This pull request ensures you're using the latest version of the image and changes `silintl/php7-apache` to the latest tag: `7.4.19`

New base image: `silintl/php7-apache:7.4.19`