### PR TITLE
Add CODEOWNERS file to specify default reviewer (esp. for automated PRs)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file specifies default reviewers (among other effects). For details, see
+# https://stackoverflow.com/a/46346494
+
+# Default owners(/reviewers) for everything in this repo:
+      @forevermatt


### PR DESCRIPTION
### Fixed
- Set up a default reviewer so that automated PRs will also automatically notify someone