### PR TITLE
Switch PHP base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="matt_henderson@sil.org"
 RUN apt-get update -y && \
     apt-get install -y \
 # Needed to install s3cmd
-        python-pip && \
+        python3-pip && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM silintl/php7-apache:7.4.23
+FROM silintl/php7:7.4
 LABEL maintainer="matt_henderson@sil.org"
 
 RUN apt-get update -y && \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Your Dockerfile should (in this order)...
 ## A Note About Semantic Versioning ##
 The environment variables that this code uses are (for the purposes of
 semantic versioning) considered this code's public interface. That is how
-backwards-compability will be determined. If a new version of this code is
+backwards-compatibility will be determined. If a new version of this code is
 released that bumps the major version number (e.g. from `1.x.y` to `2.0.0`),
 you will probably have to change something about what environment variables
 you are providing when running this Docker image.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
 
     base:
         build: .
-        image: developer-portal-local
+        image: silintl/developer-portal:local
 
     db:
         image: mariadb:10
@@ -39,7 +39,7 @@ services:
             MYSQL_PASSWORD: developer_portal
 
     web:
-        image: developer-portal-local
+        image: silintl/developer-portal:local
         depends_on:
             - base
         volumes_from:
@@ -55,7 +55,7 @@ services:
             - ./local.env
 
     composer:
-        image: developer-portal-local
+        image: silintl/developer-portal:local
         depends_on:
             - base
         volumes_from:
@@ -64,7 +64,7 @@ services:
         command: composer install --no-scripts
 
     composerupdate:
-        image: developer-portal-local
+        image: silintl/developer-portal:local
         depends_on:
             - base
         volumes_from:
@@ -73,7 +73,7 @@ services:
         command: bash -c "composer update --no-scripts; composer show --direct --format=json > direct-dependencies.json"
 
     yiimigrate:
-        image: developer-portal-local
+        image: silintl/developer-portal:local
         depends_on:
             - base
         volumes_from:
@@ -87,7 +87,7 @@ services:
         command: bash -c "whenavail db 3306 100 ./yiic migrate --interactive=0"
 
     yiimigratetestdb:
-        image: developer-portal-local
+        image: silintl/developer-portal:local
         depends_on:
             - base
         volumes_from:
@@ -104,7 +104,7 @@ services:
           MYSQL_DATABASE: test
 
     phpunit:
-        image: developer-portal-local
+        image: silintl/developer-portal:local
         depends_on:
             - base
         volumes_from:
@@ -147,7 +147,7 @@ services:
         command: proxy 80 -q
 
     axlesetup:
-        image: developer-portal-local
+        image: silintl/developer-portal:local
         depends_on:
             - base
         links:


### PR DESCRIPTION
### Fixed
- Switch docker-compose name for local image to :local tag of real name 
- Fix python-pip / python3-pip apt dependency change
  * Fixes #194
- Switch to using our standard PHP 7.4 docker image
- Fix typo in README