### PR TITLE
Use updated ApiAxle Docker image for local development and CI/CD tests

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -10,7 +10,7 @@ redis:
     image: redis:latest
 
 api:
-    image: apiaxle/apiaxle:1.15.0
+    image: silintl/apiaxle-js:1.15.2
     environment:
         REDIS_HOST: redis
         REDIS_PORT: 6379
@@ -24,7 +24,7 @@ api:
     command: api 80
 
 proxy:
-    image: apiaxle/apiaxle:1.15.0
+    image: silintl/apiaxle-js:1.15.2
     environment:
         REDIS_HOST: redis
         REDIS_PORT: 6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,7 @@ services:
         image: redis:latest
 
     api:
-        image: apiaxle/apiaxle:1.15.0
+        image: silintl/apiaxle-js:1.15.2
         links:
             - redis
         ports:
@@ -138,7 +138,7 @@ services:
         command: api 80
 
     proxy:
-        image: apiaxle/apiaxle:1.15.0
+        image: silintl/apiaxle-js:1.15.2
         links:
             - api
             - redis


### PR DESCRIPTION
### Fixed
- Use updated ApiAxle Docker image for local development and CI/CD tests